### PR TITLE
Add preferred username mapper for Kong client

### DIFF
--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -19,7 +19,23 @@
     "webOrigins": ["+"],
     "standardFlowEnabled": true,
     "directAccessGrantsEnabled": false,
-    "attributes": { "post.logout.redirect.uris": "http://localhost:8000/*" }
+    "attributes": { "post.logout.redirect.uris": "http://localhost:8000/*" },
+    "protocolMappers": [
+    {
+    "name": "preferred username",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-usermodel-property-mapper",
+    "consentRequired": false,
+    "config": {
+    "userinfo.token.claim": "true",
+    "user.attribute": "username",
+    "id.token.claim": "true",
+    "access.token.claim": "true",
+    "claim.name": "preferred_username",
+    "jsonType.label": "String"
+    }
+    }
+    ]
     }
     ],
     "authenticationFlows": [


### PR DESCRIPTION
## Summary
- add an OpenID Connect protocol mapper to the Kong client so preferred_username is sent in tokens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db1bb393ec8324bcf2e0482e3a48ac