### PR TITLE
Restructure Kong declarative config for services and OIDC scopes

### DIFF
--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -1,64 +1,90 @@
 _format_version: "3.0"
-- name: ledger
-paths: [ /api/ledger ]
-strip_path: false
-plugins:
-- name: openid-connect
-config:
-issuer: http://keycloak:8080/realms/innover
-client_id: kong
-client_secret: ${KONG_OIDC_CLIENT_SECRET}
-scopes: [ "openid" ]
-upstream_headers_claims: [ "sub", "preferred_username" ]
-upstream_headers_names: [ "x-sub", "x-username" ]
-
-
-- name: wallet-svc
-url: http://wallet:8000
-routes:
-- name: wallet
-paths: [ /api/wallet ]
-strip_path: false
-plugins:
-- name: openid-connect
-config:
-issuer: http://keycloak:8080/realms/innover
-client_id: kong
-client_secret: ${KONG_OIDC_CLIENT_SECRET}
-scopes: [ "openid" ]
-upstream_headers_claims: [ "sub", "preferred_username" ]
-upstream_headers_names: [ "x-sub", "x-username" ]
-
-
-- name: rule-engine-svc
-url: http://rule-engine:8000
-routes:
-- name: rules
-paths: [ /api/rules ]
-strip_path: false
-plugins:
-- name: openid-connect
-config:
-issuer: http://keycloak:8080/realms/innover
-client_id: kong
-client_secret: ${KONG_OIDC_CLIENT_SECRET}
-scopes: [ "openid" ]
-upstream_headers_claims: [ "sub", "preferred_username" ]
-upstream_headers_names: [ "x-sub", "x-username" ]
-
-
-- name: forex-svc
-url: http://forex:8000
-routes:
-- name: forex
-paths: [ /api/fx ]
-strip_path: false
-plugins:
-- name: openid-connect
-config:
-issuer: http://keycloak:8080/realms/innover
-client_id: kong
-client_secret: ${KONG_OIDC_CLIENT_SECRET}
-scopes: [ "openid" ]
-upstream_headers_claims: [ "sub", "preferred_username" ]
-upstream_headers_names: [ "x-sub", "x-username" ]
+services:
+  - name: ledger-svc
+    url: http://ledger:8000
+    routes:
+      - name: ledger
+        paths:
+          - /api/ledger
+        strip_path: false
+        plugins:
+          - name: openid-connect
+            config:
+              issuer: http://keycloak:8080/realms/innover
+              client_id: kong
+              client_secret: ${KONG_OIDC_CLIENT_SECRET}
+              scopes:
+                - openid
+                - profile
+              upstream_headers_claims:
+                - sub
+                - preferred_username
+              upstream_headers_names:
+                - x-sub
+                - x-username
+  - name: wallet-svc
+    url: http://wallet:8000
+    routes:
+      - name: wallet
+        paths:
+          - /api/wallet
+        strip_path: false
+        plugins:
+          - name: openid-connect
+            config:
+              issuer: http://keycloak:8080/realms/innover
+              client_id: kong
+              client_secret: ${KONG_OIDC_CLIENT_SECRET}
+              scopes:
+                - openid
+                - profile
+              upstream_headers_claims:
+                - sub
+                - preferred_username
+              upstream_headers_names:
+                - x-sub
+                - x-username
+  - name: rule-engine-svc
+    url: http://rule-engine:8000
+    routes:
+      - name: rules
+        paths:
+          - /api/rules
+        strip_path: false
+        plugins:
+          - name: openid-connect
+            config:
+              issuer: http://keycloak:8080/realms/innover
+              client_id: kong
+              client_secret: ${KONG_OIDC_CLIENT_SECRET}
+              scopes:
+                - openid
+                - profile
+              upstream_headers_claims:
+                - sub
+                - preferred_username
+              upstream_headers_names:
+                - x-sub
+                - x-username
+  - name: forex-svc
+    url: http://forex:8000
+    routes:
+      - name: forex
+        paths:
+          - /api/fx
+        strip_path: false
+        plugins:
+          - name: openid-connect
+            config:
+              issuer: http://keycloak:8080/realms/innover
+              client_id: kong
+              client_secret: ${KONG_OIDC_CLIENT_SECRET}
+              scopes:
+                - openid
+                - profile
+              upstream_headers_claims:
+                - sub
+                - preferred_username
+              upstream_headers_names:
+                - x-sub
+                - x-username


### PR DESCRIPTION
## Summary
- restructure the Kong declarative config so services are defined under `services` with their upstream URLs and routes
- move the `openid-connect` plugin definitions under each route and request both `openid` and `profile` scopes
- validate the updated YAML structure by parsing it programmatically

## Testing
- python - <<'PY'
import yaml
from pathlib import Path
yaml.safe_load(Path('kong/kong.yml').read_text())
print('YAML parsed successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68db1bd07f348324b6c8e40fd043746c