### PR TITLE
Fix OTEL collector YAML indentation

### DIFF
--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -1,26 +1,23 @@
 receivers:
-otlp:
-protocols:
-grpc:
-endpoint: 0.0.0.0:4317
-
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
 
 exporters:
-otlp:
-endpoint: jaeger:4317
-tls:
-insecure: true
-logging:
-loglevel: info
-
+  otlp:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+  logging:
+    loglevel: info
 
 processors:
-batch: {}
-
+  batch: {}
 
 service:
-pipelines:
-traces:
-receivers: [otlp]
-processors: [batch]
-exporters: [otlp, logging]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp, logging]


### PR DESCRIPTION
## Summary
- fix the nesting indentation for receivers, exporters, processors, and service pipelines in the OTEL collector configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1bcf89148324865b1265c0be9d06