### PR TITLE
Add global openid-connect plugin declaration for Kong config

### DIFF
--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -1,4 +1,6 @@
 _format_version: "3.0"
+plugins:
+  - name: openid-connect
 services:
   - name: ledger-svc
     url: http://ledger:8000


### PR DESCRIPTION
## Summary
- declare the openid-connect plugin in the top-level plugins block of the Kong declarative config so the plugin is available instance-wide

## Testing
- `kong config parse kong/kong.yml` *(fails: kong command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db20de83bc8324b94b709962ed7044