### PR TITLE
Add custom Kong image with OpenID Connect plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,16 @@ services:
       - "8081:8080"
 
   kong:
-    image: kong:latest
+    build: ./kong
     environment:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /kong/kong.yml
       KONG_PROXY_LISTEN: "0.0.0.0:8000"
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
       KONG_LOG_LEVEL: notice
+      KONG_PLUGINS: "bundled,openid-connect"
+      KONG_LUA_PACKAGE_PATH: "/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;;"
+      KONG_OIDC_CLIENT_SECRET: ${KONG_OIDC_CLIENT_SECRET:-changeme}
     volumes:
       - ./kong/kong.yml:/kong/kong.yml:ro
     ports:

--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -1,0 +1,16 @@
+FROM kong:latest
+
+USER root
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends git; \
+    rm -rf /var/lib/apt/lists/*; \
+    mkdir -p /tmp/kong-plugins && \
+    git clone --depth=1 https://github.com/nokia/kong-plugins.git /tmp/kong-plugins && \
+    mkdir -p /usr/local/share/lua/5.1/kong/plugins && \
+    cp -r /tmp/kong-plugins/kong/plugins/openid-connect /usr/local/share/lua/5.1/kong/plugins/openid-connect && \
+    rm -rf /tmp/kong-plugins && \
+    chown -R kong:kong /usr/local/share/lua/5.1/kong/plugins/openid-connect
+
+USER kong


### PR DESCRIPTION
## Summary
- build a custom Kong image that bundles the community openid-connect plugin
- configure docker-compose to use the new image and expose plugin-related settings

## Testing
- not run (Docker not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68db27d0529c8324a62d6aff76a4a7bb