### PR TITLE
Vendor openid-connect plugin for Kong

### DIFF
--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -3,14 +3,10 @@ FROM kong:latest
 USER root
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends git; \
-    rm -rf /var/lib/apt/lists/*; \
-    mkdir -p /tmp/kong-plugins && \
-    git clone --depth=1 https://github.com/nokia/kong-plugins.git /tmp/kong-plugins && \
-    mkdir -p /usr/local/share/lua/5.1/kong/plugins && \
-    cp -r /tmp/kong-plugins/kong/plugins/openid-connect /usr/local/share/lua/5.1/kong/plugins/openid-connect && \
-    rm -rf /tmp/kong-plugins && \
-    chown -R kong:kong /usr/local/share/lua/5.1/kong/plugins/openid-connect
+    mkdir -p /usr/local/share/lua/5.1/kong/plugins/openid-connect
+
+COPY vendor/openid-connect /usr/local/share/lua/5.1/kong/plugins/openid-connect
+
+RUN chown -R kong:kong /usr/local/share/lua/5.1/kong/plugins/openid-connect
 
 USER kong

--- a/kong/vendor/openid-connect/LICENSE
+++ b/kong/vendor/openid-connect/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kong/vendor/openid-connect/README.md
+++ b/kong/vendor/openid-connect/README.md
@@ -1,0 +1,9 @@
+# Vendored OpenID Connect Kong Plugin
+
+This directory vendors a lightly adapted version of the Nokia "kong-oidc" plugin so the build no longer needs to clone the upstream repository at image build time.  The code has been updated to:
+
+* run without the deprecated `BasePlugin` helper (compatible with modern Kong versions),
+* expose the plugin under the `openid-connect` name, and
+* support mapping configured claims onto upstream headers used by the stack.
+
+The original project is available at https://github.com/nokia/kong-oidc and is distributed under the Apache 2.0 License (see `LICENSE`).

--- a/kong/vendor/openid-connect/filter.lua
+++ b/kong/vendor/openid-connect/filter.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+local function shouldIgnoreRequest(patterns)
+  if (patterns) then
+    for _, pattern in ipairs(patterns) do
+      local isMatching = not (string.find(ngx.var.uri, pattern) == nil)
+      if (isMatching) then return true end
+    end
+  end
+  return false
+end
+
+function M.shouldProcessRequest(config)
+  return not shouldIgnoreRequest(config.filters)
+end
+
+return M

--- a/kong/vendor/openid-connect/handler.lua
+++ b/kong/vendor/openid-connect/handler.lua
@@ -1,0 +1,71 @@
+local kong = kong
+local resty_openidc = require("resty.openidc")
+local utils = require("kong.plugins.openid-connect.utils")
+local filter = require("kong.plugins.openid-connect.filter")
+local session = require("kong.plugins.openid-connect.session")
+
+local OpenIDConnectHandler = {
+  PRIORITY = 1000,
+  VERSION = "1.0.0",
+}
+
+local function handle_authentication(conf, oidc_opts)
+  if oidc_opts.introspection_endpoint then
+    local introspection_res, introspection_err = resty_openidc.introspect(oidc_opts)
+    if introspection_err then
+      kong.log.err("OIDC introspection error: ", introspection_err)
+      if conf.bearer_only then
+        return utils.exit(401, introspection_err, 401)
+      end
+    elseif introspection_res then
+      utils.inject_user(introspection_res, conf)
+      return
+    end
+  end
+
+  local res, err = resty_openidc.authenticate(oidc_opts)
+  if err then
+    if oidc_opts.recovery_page_path then
+      kong.log.debug("OIDC redirecting to recovery page", oidc_opts.recovery_page_path)
+      return ngx.redirect(oidc_opts.recovery_page_path)
+    end
+
+    kong.log.err("OIDC authentication error: ", err)
+    return utils.exit(500, err, 500)
+  end
+
+  if not res then
+    return
+  end
+
+  if res.user then
+    utils.inject_user(res.user, conf)
+  end
+
+  if res.access_token then
+    utils.inject_access_token(res.access_token)
+  end
+
+  if res.id_token then
+    utils.inject_id_token(res.id_token)
+  end
+end
+
+function OpenIDConnectHandler:access(conf)
+  local _, err = session.configure(conf)
+  if err then
+    kong.log.err(err)
+    return utils.exit(500, err, 500)
+  end
+
+  local oidc_opts = utils.get_options(conf)
+
+  if not filter.shouldProcessRequest(oidc_opts) then
+    kong.log.debug("OIDC plugin ignoring request: ", ngx.var.request_uri)
+    return
+  end
+
+  handle_authentication(conf, oidc_opts)
+end
+
+return OpenIDConnectHandler

--- a/kong/vendor/openid-connect/schema.lua
+++ b/kong/vendor/openid-connect/schema.lua
@@ -1,0 +1,55 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+local function validate_header_mappings(entity)
+  local claims = entity.upstream_headers_claims or {}
+  local names = entity.upstream_headers_names or {}
+
+  if #claims ~= #names then
+    return nil, "config.upstream_headers_claims and config.upstream_headers_names must contain the same number of values"
+  end
+
+  return true
+end
+
+return {
+  name = "openid-connect",
+  fields = {
+    { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { issuer = { type = "string", required = true } },
+          { discovery = { type = "string" } },
+          { client_id = { type = "string", required = true } },
+          { client_secret = { type = "string", required = true } },
+          { scopes = { type = "array", required = false, default = { "openid" }, elements = { type = "string" } } },
+          { audience = { type = "string" } },
+          { response_type = { type = "string", required = false, default = "code" } },
+          { bearer_only = { type = "boolean", required = false, default = false } },
+          { realm = { type = "string", required = false, default = "kong" } },
+          { timeout = { type = "integer" } },
+          { introspection_endpoint = { type = "string" } },
+          { introspection_endpoint_auth_method = { type = "string" } },
+          { redirect_uri_path = { type = "string" } },
+          { ssl_verify = { type = "boolean", required = false, default = false } },
+          { token_endpoint_auth_method = { type = "string", required = false, default = "client_secret_post" } },
+          { session_secret = { type = "string" } },
+          { recovery_page_path = { type = "string" } },
+          { logout_path = { type = "string", required = false, default = "/logout" } },
+          { redirect_after_logout_uri = { type = "string", required = false, default = "/" } },
+          { filters = { type = "array", required = false, default = {}, elements = { type = "string" } } },
+          { upstream_headers_claims = { type = "array", required = false, default = {}, elements = { type = "string" } } },
+          { upstream_headers_names = { type = "array", required = false, default = {}, elements = { type = "string" } } },
+        },
+        entity_checks = {
+          { custom_entity_check = {
+              field_sources = { "upstream_headers_claims", "upstream_headers_names" },
+              fn = validate_header_mappings,
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/kong/vendor/openid-connect/session.lua
+++ b/kong/vendor/openid-connect/session.lua
@@ -1,0 +1,15 @@
+local _M = {}
+
+function _M.configure(conf)
+  if conf.session_secret then
+    local decoded_session_secret = ngx.decode_base64(conf.session_secret)
+    if not decoded_session_secret then
+      return nil, "invalid OIDC plugin configuration, session secret could not be decoded"
+    end
+    ngx.var.session_secret = decoded_session_secret
+  end
+
+  return true
+end
+
+return _M

--- a/kong/vendor/openid-connect/utils.lua
+++ b/kong/vendor/openid-connect/utils.lua
@@ -1,0 +1,177 @@
+local cjson = require("cjson")
+local kong = kong
+
+local _M = {}
+
+local function join_scope(scopes)
+  if type(scopes) ~= "table" then
+    return scopes or "openid"
+  end
+
+  if #scopes == 0 then
+    return "openid"
+  end
+
+  return table.concat(scopes, " ")
+end
+
+local function ensure_discovery(conf)
+  if conf.discovery and conf.discovery ~= "" then
+    return conf.discovery
+  end
+
+  local issuer = conf.issuer or ""
+  if issuer == "" then
+    return nil
+  end
+
+  if issuer:sub(-1) == "/" then
+    return issuer .. ".well-known/openid-configuration"
+  end
+
+  return issuer .. "/.well-known/openid-configuration"
+end
+
+function _M.get_redirect_uri_path()
+  local function drop_query()
+    local uri = ngx.var.request_uri
+    local x = uri and uri:find("?")
+    if x then
+      return uri:sub(1, x - 1)
+    else
+      return uri
+    end
+  end
+
+  local function tackle_slash(path)
+    local args = ngx.req.get_uri_args()
+    if args and args.code then
+      return path
+    elseif path == "/" then
+      return "/cb"
+    elseif path:sub(-1) == "/" then
+      return path:sub(1, -2)
+    else
+      return path .. "/"
+    end
+  end
+
+  return tackle_slash(drop_query())
+end
+
+function _M.get_options(conf)
+  local discovery = ensure_discovery(conf)
+
+  local opts = {
+    client_id = conf.client_id,
+    client_secret = conf.client_secret,
+    discovery = discovery,
+    introspection_endpoint = conf.introspection_endpoint,
+    timeout = conf.timeout,
+    introspection_endpoint_auth_method = conf.introspection_endpoint_auth_method,
+    bearer_only = conf.bearer_only and "yes" or "no",
+    realm = conf.realm,
+    redirect_uri_path = conf.redirect_uri_path or _M.get_redirect_uri_path(),
+    scope = join_scope(conf.scopes),
+    response_type = conf.response_type,
+    ssl_verify = conf.ssl_verify and "yes" or "no",
+    token_endpoint_auth_method = conf.token_endpoint_auth_method,
+    recovery_page_path = conf.recovery_page_path,
+    filters = conf.filters or {},
+    logout_path = conf.logout_path,
+    redirect_after_logout_uri = conf.redirect_after_logout_uri,
+  }
+
+  if conf.audience then
+    opts.audience = conf.audience
+  end
+
+  return opts
+end
+
+function _M.exit(http_status_code, message, kong_status_code)
+  kong.response.set_header("Content-Type", "application/json")
+  return kong.response.exit(kong_status_code or http_status_code, { message = message })
+end
+
+local function normalize_claim_value(value)
+  if value == nil then
+    return nil
+  end
+
+  if type(value) == "table" then
+    return table.concat(value, ",")
+  end
+
+  return tostring(value)
+end
+
+function _M.inject_access_token(access_token)
+  if not access_token then
+    return
+  end
+
+  kong.service.request.set_header("X-Access-Token", access_token)
+end
+
+function _M.inject_id_token(id_token)
+  if not id_token then
+    return
+  end
+
+  local token_str = cjson.encode(id_token)
+  kong.service.request.set_header("X-ID-Token", ngx.encode_base64(token_str))
+end
+
+local function set_header(name, value)
+  if not name or name == "" or value == nil then
+    return
+  end
+
+  kong.service.request.set_header(name, value)
+end
+
+function _M.inject_user(user, conf)
+  if not user then
+    return
+  end
+
+  local tmp_user = {}
+  for k, v in pairs(user) do
+    tmp_user[k] = v
+  end
+  tmp_user.id = user.sub
+  tmp_user.username = user.preferred_username or user.sub
+  kong.ctx.shared.authenticated_credential = tmp_user
+
+  local userinfo = cjson.encode(user)
+  kong.service.request.set_header("X-Userinfo", ngx.encode_base64(userinfo))
+
+  local claims = conf.upstream_headers_claims or {}
+  local names = conf.upstream_headers_names or {}
+
+  for idx, claim in ipairs(claims) do
+    local header_name = names[idx]
+    local value = normalize_claim_value(user[claim])
+    if header_name and value then
+      set_header(header_name, value)
+    end
+  end
+end
+
+function _M.has_bearer_access_token()
+  local header = kong.request.get_header("Authorization")
+  if header then
+    local divider = header:find(" ")
+    if divider then
+      local prefix = header:sub(1, divider - 1)
+      if prefix:lower() == "bearer" then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
+return _M


### PR DESCRIPTION
## Summary
- vendor the openid-connect plugin code under `kong/vendor/openid-connect` and adapt it for the stack's configuration
- update the Kong Dockerfile to copy the vendored plugin instead of cloning the upstream repository at build time

## Testing
- docker compose build kong *(fails in CI environment: `docker` command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68db297e251c8324b62e25b0d4fead2b