### PR TITLE
Install OpenID dependencies in Kong Dockerfile

### DIFF
--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -3,6 +3,10 @@ FROM kong:latest
 USER root
 
 RUN set -eux; \
+    luarocks install lua-resty-openidc 1.7.5-1; \
+    luarocks install lua-resty-session 3.11-1
+
+RUN set -eux; \
     mkdir -p /usr/local/share/lua/5.1/kong/plugins/openid-connect
 
 COPY vendor/openid-connect /usr/local/share/lua/5.1/kong/plugins/openid-connect


### PR DESCRIPTION
## Summary
- install lua-resty-openidc and lua-resty-session via luarocks in the Kong image build
- retain copying of the vendored OpenID Connect plugin with kong ownership

## Testing
- not run (Docker CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68db2d0a95208324b635e63f9c88eeff