### PR TITLE
Add curl installation to Kong Dockerfile

### DIFF
--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -3,6 +3,11 @@ FROM kong:latest
 USER root
 
 RUN set -eux; \
+    apt-get update; \
+    apt-get install -y curl; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
     luarocks install lua-resty-openidc 1.7.5-1; \
     luarocks install lua-resty-session 3.11-1
 


### PR DESCRIPTION
## Summary
- install curl in the Kong Docker image before running LuaRocks
- clean up apt lists after installation to keep the image lean

## Testing
- ⚠️ `docker compose build kong` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db2e6a68cc83248b40581ceb695706