### PR TITLE
Update lua-resty-session dependency version

### DIFF
--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux; \
 
 RUN set -eux; \
     luarocks install lua-resty-openidc 1.7.5-1; \
-    luarocks install lua-resty-session 3.11-1
+    luarocks install lua-resty-session 4.0.5-1
 
 RUN set -eux; \
     mkdir -p /usr/local/share/lua/5.1/kong/plugins/openid-connect


### PR DESCRIPTION
## Summary
- update the lua-resty-session LuaRocks dependency to version 4.0.5-1 so it remains compatible with Lua 5.1

## Testing
- docker compose build kong *(fails: `docker` command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db30bede888324b72057381a5b65f6