### PR TITLE
Fix Kong OIDC configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       KONG_LOG_LEVEL: notice
       KONG_PLUGINS: "bundled,openid-connect"
       KONG_LUA_PACKAGE_PATH: "/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;;"
-      KONG_OIDC_CLIENT_SECRET: ${KONG_OIDC_CLIENT_SECRET:-changeme}
+      KONG_OIDC_CLIENT_SECRET: ${KONG_OIDC_CLIENT_SECRET:-kong-secret}
     volumes:
       - ./kong/kong.yml:/kong/kong.yml:ro
     ports:

--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -1,6 +1,4 @@
 _format_version: "3.0"
-plugins:
-  - name: openid-connect
 services:
   - name: ledger-svc
     url: http://ledger:8000


### PR DESCRIPTION
## Summary
- remove the unused global openid-connect plugin entry from the declarative config
- set the Kong OIDC client secret default to match the Keycloak client secret so declarative config validation succeeds

## Testing
- docker compose build kong *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db31fac78c83249099a6246128e795