### PR TITLE
Refine cockroach init command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,13 +140,11 @@ services:
   # One-time init job to create app database(s) and users (optional)
   cockroach-init:
     image: cockroachdb/cockroach:v24.2.5
-    command: >
-      sh -c "
-      /cockroach/cockroach sql --insecure --host=cockroach1:26257 -e
-      \"CREATE DATABASE IF NOT EXISTS innover;
-         CREATE USER IF NOT EXISTS fin WITH PASSWORD 'finpass';
-         GRANT ALL ON DATABASE innover TO fin;\"
-      "
+    command:
+      - sql
+      - --insecure
+      - --host=cockroach1:26257
+      - --execute=CREATE DATABASE IF NOT EXISTS innover; CREATE USER IF NOT EXISTS fin WITH PASSWORD 'finpass'; GRANT ALL ON DATABASE innover TO fin;
     depends_on: [cockroach1, cockroach2, cockroach3]
     restart: "no"
 


### PR DESCRIPTION
## Summary
- update the cockroach-init service command to call the sql subcommand directly via the default entrypoint

## Testing
- `docker compose up cockroach-init` *(fails: docker CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3378ec9c83248ff71697211cdd53