### PR TITLE
Switch OpenTelemetry collector to debug exporter

### DIFF
--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -9,8 +9,8 @@ exporters:
     endpoint: jaeger:4317
     tls:
       insecure: true
-  logging:
-    loglevel: info
+  debug:
+    verbosity: detailed
 
 processors:
   batch: {}
@@ -20,4 +20,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]


### PR DESCRIPTION
## Summary
- replace the OpenTelemetry Collector logging exporter with the debug exporter
- update the traces pipeline to forward data to the debug exporter

## Testing
- docker compose up otel-collector *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db34bbbe5483248d57a17a21f76ce8