### PR TITLE
Update CockroachDB healthcheck host to advertised SQL endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-svc-env: &svc_env
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
 
 x-cockroach-healthcheck: &cockroach_healthcheck
-  test: ["CMD-SHELL", "cockroach sql --insecure --host=localhost:26257 -e 'SELECT 1'"]
+  test: ["CMD-SHELL", "cockroach sql --insecure --host=$$(hostname -f):26257 -e 'SELECT 1'"]
   interval: 5s
   timeout: 5s
   retries: 12


### PR DESCRIPTION
## Summary
- update the shared CockroachDB healthcheck to use the container hostname via `hostname -f`
- ensure each CockroachDB service continues referencing the shared healthcheck template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db42079b3083248a93197e02537edb