### PR TITLE
Fix CockroachDB healthcheck host resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-svc-env: &svc_env
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
 
 x-cockroach-healthcheck: &cockroach_healthcheck
-  test: ["CMD", "curl", "-fsS", "http://localhost:8080/health?ready=1"]
+  test: ["CMD-SHELL", "curl -fsS http://$(hostname -f):8080/health?ready=1"]
   interval: 10s
   timeout: 5s
   retries: 5


### PR DESCRIPTION
## Summary
- update the CockroachDB healthcheck template to curl the node hostname so the HTTP port matches the listen address

## Testing
- docker compose up --build *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db45c1e4248324a7507f551f36afea