### PR TITLE
Add Celery scaffolding for core services

### DIFF
--- a/services/forex/app/__init__.py
+++ b/services/forex/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/forex/app/celery_app.py
+++ b/services/forex/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/forex/app/requirements.txt
+++ b/services/forex/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/forex/app/tasks.py
+++ b/services/forex/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="forex.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="forex.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds

--- a/services/ledger/app/__init__.py
+++ b/services/ledger/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/ledger/app/celery_app.py
+++ b/services/ledger/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/ledger/app/requirements.txt
+++ b/services/ledger/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/ledger/app/tasks.py
+++ b/services/ledger/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="ledger.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="ledger.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds

--- a/services/payment/app/__init__.py
+++ b/services/payment/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/payment/app/celery_app.py
+++ b/services/payment/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/payment/app/requirements.txt
+++ b/services/payment/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/payment/app/tasks.py
+++ b/services/payment/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="payment.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="payment.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds

--- a/services/profile/app/__init__.py
+++ b/services/profile/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/profile/app/celery_app.py
+++ b/services/profile/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/profile/app/requirements.txt
+++ b/services/profile/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/profile/app/tasks.py
+++ b/services/profile/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="profile.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="profile.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds

--- a/services/rule-engine/app/__init__.py
+++ b/services/rule-engine/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/rule-engine/app/celery_app.py
+++ b/services/rule-engine/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/rule-engine/app/requirements.txt
+++ b/services/rule-engine/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/rule-engine/app/tasks.py
+++ b/services/rule-engine/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="rule_engine.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="rule_engine.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds

--- a/services/wallet/app/__init__.py
+++ b/services/wallet/app/__init__.py
@@ -1,0 +1,3 @@
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/services/wallet/app/celery_app.py
+++ b/services/wallet/app/celery_app.py
@@ -1,0 +1,18 @@
+import os
+from celery import Celery
+
+broker = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery(
+    __name__,
+    broker=broker,
+    backend=broker,
+    include=["tasks"],
+)
+
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    enable_utc=True,
+    timezone="UTC",
+)

--- a/services/wallet/app/requirements.txt
+++ b/services/wallet/app/requirements.txt
@@ -1,0 +1,1 @@
+celery[redis]==5.4.0

--- a/services/wallet/app/tasks.py
+++ b/services/wallet/app/tasks.py
@@ -1,0 +1,16 @@
+import time
+
+from .celery_app import celery_app
+
+
+@celery_app.task(name="wallet.add")
+def add(x, y):
+    """Add two numbers together."""
+    return x + y
+
+
+@celery_app.task(name="wallet.slow")
+def slow(seconds):
+    """Sleep for the provided duration and return it."""
+    time.sleep(seconds)
+    return seconds


### PR DESCRIPTION
## Summary
- add Celery application setup for each service with shared Redis-backed configuration
- expose example add and slow tasks per service namespaced to avoid collisions
- declare the Celery redis dependency in every service requirements file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd31066c08324bd48141d7984978f