### PR TITLE
Update Makefile utility targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,32 @@
 SHELL := /bin/bash
 
-.PHONY: up down rebuild logs proto keycloak-url
+.PHONY: up down rebuild logs ps proto keycloak-url
 
 up:
-docker compose up -d --build
+	docker compose up -d --build
 
 rebuild:
-docker compose build --no-cache
+	docker compose build --no-cache
 
 logs:
-docker compose logs -f --tail=200
+	docker compose logs -f --tail=200
 
 down:
-docker compose down -v
+	docker compose down -v
+
+ps:
+	docker compose ps
 
 proto:
-python -m pip install --quiet grpcio-tools || true
-bash generate_protos.sh
+	bash ./generate_protos.sh
 
 keycloak-url:
-@echo "Keycloak → http://localhost:8081"
-@echo "Kong Gateway → http://localhost:8000"
-@echo "Jaeger UI → http://localhost:16686"
+	@echo "Keycloak: http://localhost:8081"
+	@echo "Kong: http://localhost:8000"
+	@echo "Jaeger: http://localhost:16686"
+	@echo "Redpanda: http://localhost:8080"
+	@echo "Cockroach: http://localhost:8082"
+	@if docker compose config --services | grep -qx 'flower'; then \
+		echo "Flower: http://localhost:5555"; \
+	fi
+


### PR DESCRIPTION
## Summary
- ensure all Makefile recipes use tabs and add a `ps` target to the phony list
- simplify the `proto` recipe to invoke the existing generation script directly
- refresh the `keycloak-url` output to provide colon-formatted service URLs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd311c488832493fd4b453c01fbe7