### PR TITLE
Use absolute Celery imports in worker tasks

### DIFF
--- a/services/forex/app/tasks.py
+++ b/services/forex/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="forex.add")

--- a/services/ledger/app/tasks.py
+++ b/services/ledger/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="ledger.add")

--- a/services/payment/app/tasks.py
+++ b/services/payment/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="payment.add")

--- a/services/profile/app/tasks.py
+++ b/services/profile/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="profile.add")

--- a/services/rule-engine/app/tasks.py
+++ b/services/rule-engine/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="rule_engine.add")

--- a/services/wallet/app/tasks.py
+++ b/services/wallet/app/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from .celery_app import celery_app
+from celery_app import celery_app
 
 
 @celery_app.task(name="wallet.add")


### PR DESCRIPTION
## Summary
- switch each worker task module to import celery_app via absolute import so Celery workers run from package root

## Testing
- docker compose up profile-worker payment-worker ledger-worker wallet-worker rule-engine-worker forex-worker *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd7e11dcc83249fa96ae25532413a