### PR TITLE
Add resource limits and restart policies to compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ The compose stack bootstraps every dependency you need to exercise the services 
 - **Redis 7** provides a lightweight cache/message store on `localhost:6379`.
 - **Redpanda** serves as the Kafka-compatible event broker with a single-node developer configuration bound to `localhost:9092` and persisted in a named volume.
 
+## Resource limits and local tuning
+The default `docker-compose.yml` now applies conservative CPU and memory caps to each container using `deploy.resources.limits`.
+The anchors defined near the top of the file (`x-default-deploy`, `x-worker-deploy`, `x-support-deploy`, etc.) describe the
+limits that are shared by common container types (HTTP APIs, Celery workers, infrastructure services, and databases). Adjust
+these anchors to change the limits globally for each service category, or override an individual service by editing its
+`deploy` block directly. The values are intentionally modest so that the entire stack can run on a developer laptop; if you need
+more headroom for load testing, increase the `cpus` and `memory` values and restart the affected containers with
+`docker compose up -d <service>`. Remember that Docker Compose will ignore these settings outside of Swarm mode but Docker will
+still honour the cgroup constraints when the stack is running locally.
+
 ## Identity and API gateway
 The identity layer is prewired so that local OAuth/OIDC flows work out of the box:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,36 @@ x-svc-env: &svc_env
   OIDC_AUDIENCE: ${OIDC_AUDIENCE:-kong}
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
 
+x-default-deploy: &default_deploy
+  resources:
+    limits:
+      cpus: "0.50"
+      memory: 512M
+
+x-worker-deploy: &worker_deploy
+  resources:
+    limits:
+      cpus: "0.75"
+      memory: 768M
+
+x-db-deploy: &db_deploy
+  resources:
+    limits:
+      cpus: "2.00"
+      memory: 2G
+
+x-support-deploy: &support_deploy
+  resources:
+    limits:
+      cpus: "1.00"
+      memory: 1G
+
+x-light-deploy: &light_deploy
+  resources:
+    limits:
+      cpus: "0.25"
+      memory: 256M
+
 x-cockroach-healthcheck: &cockroach_healthcheck
   test: ["CMD-SHELL", "curl -fsS http://$(hostname -f):8080/health || exit 0"]
   interval: 10s
@@ -16,6 +46,12 @@ services:
     ports:
       - "16686:16686"
       - "4317:4317"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.00"
+          memory: 1G
+    restart: unless-stopped
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -24,6 +60,8 @@ services:
       - ./otel/collector.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
       - jaeger
+    deploy: *support_deploy
+    restart: unless-stopped
 
   keycloak:
     image: quay.io/keycloak/keycloak:latest
@@ -35,6 +73,12 @@ services:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     ports:
       - "8081:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.50"
+          memory: 1.5G
+    restart: unless-stopped
 
   kong:
     build: ./kong
@@ -54,6 +98,8 @@ services:
       - "8001:8001"
     depends_on:
       - keycloak
+    deploy: *support_deploy
+    restart: unless-stopped
 
   # -------- CockroachDB Cluster --------
   cockroach1:
@@ -77,6 +123,7 @@ services:
       - cockroach1:/cockroach/cockroach-data
     healthcheck: *cockroach_healthcheck
     restart: unless-stopped
+    deploy: *db_deploy
 
   cockroach2:
     image: cockroachdb/cockroach:v24.2.5
@@ -99,6 +146,7 @@ services:
         condition: service_started
     healthcheck: *cockroach_healthcheck
     restart: unless-stopped
+    deploy: *db_deploy
 
   cockroach3:
     image: cockroachdb/cockroach:v24.2.5
@@ -121,6 +169,7 @@ services:
         condition: service_started
     healthcheck: *cockroach_healthcheck
     restart: unless-stopped
+    deploy: *db_deploy
 
   cockroach-init-cluster:
     image: cockroachdb/cockroach:v24.2.5
@@ -156,6 +205,7 @@ services:
       cockroach3:
         condition: service_healthy
     restart: "no"
+    deploy: *default_deploy
 
   # Database and user creation
   cockroach-bootstrap:
@@ -193,6 +243,7 @@ services:
       cockroach-init-cluster:
         condition: service_completed_successfully
     restart: "no"
+    deploy: *default_deploy
 
   # -------- Application Services --------
   profile:
@@ -212,6 +263,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   profile-worker:
     build: ./services/profile
@@ -244,6 +297,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   payment:
     build: ./services/payment
@@ -262,6 +317,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   payment-worker:
     build: ./services/payment
@@ -294,6 +351,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   ledger:
     build: ./services/ledger
@@ -312,6 +371,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   ledger-worker:
     build: ./services/ledger
@@ -344,6 +405,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   wallet:
     build: ./services/wallet
@@ -362,6 +425,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   wallet-worker:
     build: ./services/wallet
@@ -394,6 +459,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   rule-engine:
     build: ./services/rule-engine
@@ -412,6 +479,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   rule-engine-worker:
     build: ./services/rule-engine
@@ -444,6 +513,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   forex:
     build: ./services/forex
@@ -462,6 +533,8 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *default_deploy
+    restart: unless-stopped
 
   forex-worker:
     build: ./services/forex
@@ -494,11 +567,15 @@ services:
         condition: service_started
       redpanda:
         condition: service_started
+    deploy: *worker_deploy
+    restart: unless-stopped
 
   # -------- Infrastructure Services --------
   redis:
     image: redis:7-alpine
     ports: ["6379:6379"]
+    deploy: *light_deploy
+    restart: unless-stopped
 
   redpanda:
     image: redpandadata/redpanda:v24.2.13
@@ -526,6 +603,12 @@ services:
       - "9092:9092"
     volumes:
       - redpanda:/var/lib/redpanda/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.50"
+          memory: 1.5G
+    restart: unless-stopped
 
 volumes:
   cockroach1:


### PR DESCRIPTION
## Summary
- add shared deploy resource limit anchors and apply them to each service in docker-compose.yml
- set conservative CPU and memory caps plus restart policies for long-running containers
- document how to adjust the limits for local testing in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddacda5af88324a31f091686bd22c9