### PR TITLE
Add health checks to core infrastructure services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
     ports:
       - "16686:16686"
       - "4317:4317"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:14269/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -23,7 +29,14 @@ services:
     volumes:
       - ./otel/collector.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
-      - jaeger
+      jaeger:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:13133/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   keycloak:
     image: quay.io/keycloak/keycloak:latest
@@ -35,6 +48,12 @@ services:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     ports:
       - "8081:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   kong:
     build: ./kong
@@ -53,7 +72,14 @@ services:
       - "8000:8000"
       - "8001:8001"
     depends_on:
-      - keycloak
+      keycloak:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   # -------- CockroachDB Cluster --------
   cockroach1:
@@ -205,13 +231,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   profile-worker:
     build: ./services/profile
@@ -237,13 +263,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   payment:
     build: ./services/payment
@@ -255,13 +281,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   payment-worker:
     build: ./services/payment
@@ -287,13 +313,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   ledger:
     build: ./services/ledger
@@ -305,13 +331,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   ledger-worker:
     build: ./services/ledger
@@ -337,13 +363,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   wallet:
     build: ./services/wallet
@@ -355,13 +381,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   wallet-worker:
     build: ./services/wallet
@@ -387,13 +413,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   rule-engine:
     build: ./services/rule-engine
@@ -405,13 +431,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   rule-engine-worker:
     build: ./services/rule-engine
@@ -437,13 +463,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   forex:
     build: ./services/forex
@@ -455,13 +481,13 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   forex-worker:
     build: ./services/forex
@@ -487,18 +513,24 @@ services:
       KAFKA_BROKERS: redpanda:9092
     depends_on:
       otel-collector:
-        condition: service_started
+        condition: service_healthy
       cockroach-bootstrap:
         condition: service_completed_successfully
       redis:
-        condition: service_started
+        condition: service_healthy
       redpanda:
-        condition: service_started
+        condition: service_healthy
 
   # -------- Infrastructure Services --------
   redis:
     image: redis:7-alpine
     ports: ["6379:6379"]
+    healthcheck:
+      test: ["CMD-SHELL", "if [ -n \"$$REDIS_PASSWORD\" ]; then redis-cli -a \"$$REDIS_PASSWORD\" ping; else redis-cli ping; fi | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   redpanda:
     image: redpandadata/redpanda:v24.2.13
@@ -526,6 +558,12 @@ services:
       - "9092:9092"
     volumes:
       - redpanda:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health --brokers localhost:9092 --exit-when-healthy --timeout 5s"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
 volumes:
   cockroach1:

--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -15,7 +15,12 @@ exporters:
 processors:
   batch: {}
 
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
## Summary
- add health checks for Jaeger, the otel collector, Keycloak, Kong, Redis, and Redpanda in docker-compose
- gate service start-up on healthy dependencies and enable the otel collector health endpoint

## Testing
- docker compose up *(fails: `docker` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddacd904508324a13e51574eb90d7b