### PR TITLE
Replace service heartbeats with FastAPI health endpoints

### DIFF
--- a/services/forex/Dockerfile
+++ b/services/forex/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/forex/app/main.py
+++ b/services/forex/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/forex/app/requirements.txt
+++ b/services/forex/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/services/ledger/Dockerfile
+++ b/services/ledger/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/ledger/app/main.py
+++ b/services/ledger/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/ledger/app/requirements.txt
+++ b/services/ledger/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/services/payment/Dockerfile
+++ b/services/payment/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/payment/app/main.py
+++ b/services/payment/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/payment/app/requirements.txt
+++ b/services/payment/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/services/profile/Dockerfile
+++ b/services/profile/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/profile/app/main.py
+++ b/services/profile/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/profile/app/requirements.txt
+++ b/services/profile/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/services/rule-engine/Dockerfile
+++ b/services/rule-engine/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/rule-engine/app/main.py
+++ b/services/rule-engine/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/rule-engine/app/requirements.txt
+++ b/services/rule-engine/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/services/wallet/Dockerfile
+++ b/services/wallet/Dockerfile
@@ -16,7 +16,9 @@ COPY app/ /app/
 
 # Minimal healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD python -c "import os; print('ok')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')" || exit 1
 
-# Run your script continuously
-CMD ["python", "-u", "main.py"]
+EXPOSE 8000
+
+# Run the FastAPI application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/wallet/app/main.py
+++ b/services/wallet/app/main.py
@@ -1,7 +1,18 @@
-import time, os, sys
-print(f"Starting {os.getenv('SERVICE_NAME','svc-unknown')}…", flush=True)
-i = 0
-while True:
-    i += 1
-    print(f"[tick {i}] alive", flush=True)
-    time.sleep(5)
+import os
+from fastapi import FastAPI
+
+SERVICE_NAME = os.getenv("SERVICE_NAME", "svc-unknown")
+
+app = FastAPI(title=SERVICE_NAME)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness probe for the service."""
+    return {"status": "ok", "service": SERVICE_NAME}
+
+
+@app.get("/readiness")
+def readiness() -> dict[str, str]:
+    """Readiness probe for upstream load balancers."""
+    return {"status": "ready", "service": SERVICE_NAME}

--- a/services/wallet/app/requirements.txt
+++ b/services/wallet/app/requirements.txt
@@ -1,1 +1,3 @@
 celery[redis]==5.4.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1


### PR DESCRIPTION
## Summary
- replace the legacy heartbeat loops in each service with a FastAPI application exposing health and readiness endpoints
- add FastAPI/uvicorn dependencies to every service requirements file and update Dockerfiles to run uvicorn on port 8000

## Testing
- python -m compileall services/*/app/main.py
- docker compose build ledger wallet rule-engine forex payment profile *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb9b5460483248aa15c32ed5a3898