### PR TITLE
Add build prerequisites to service Dockerfiles

### DIFF
--- a/services/forex/Dockerfile
+++ b/services/forex/Dockerfile
@@ -1,6 +1,10 @@
 # services/forex/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/services/ledger/Dockerfile
+++ b/services/ledger/Dockerfile
@@ -1,6 +1,10 @@
 # services/ledger/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/services/payment/Dockerfile
+++ b/services/payment/Dockerfile
@@ -1,6 +1,10 @@
 # services/payment/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/services/profile/Dockerfile
+++ b/services/profile/Dockerfile
@@ -1,6 +1,10 @@
 # services/profile/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/services/rule-engine/Dockerfile
+++ b/services/rule-engine/Dockerfile
@@ -1,6 +1,10 @@
 # services/rule-engine/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1

--- a/services/wallet/Dockerfile
+++ b/services/wallet/Dockerfile
@@ -1,6 +1,10 @@
 # services/wallet/Dockerfile
 FROM python:3.14.0rc3-slim-trixie
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1


### PR DESCRIPTION
## Summary
- install build-essential after the base image selection in each service Dockerfile to provide compiler toolchains for native Python packages

## Testing
- docker compose build *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbcde18d08324931f50f1bafddaf2