### PR TITLE
Use Python 3.12 slim base images

### DIFF
--- a/services/forex/Dockerfile
+++ b/services/forex/Dockerfile
@@ -1,5 +1,5 @@
 # services/forex/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/services/ledger/Dockerfile
+++ b/services/ledger/Dockerfile
@@ -1,5 +1,5 @@
 # services/ledger/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/services/payment/Dockerfile
+++ b/services/payment/Dockerfile
@@ -1,5 +1,5 @@
 # services/payment/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/services/profile/Dockerfile
+++ b/services/profile/Dockerfile
@@ -1,5 +1,5 @@
 # services/profile/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/services/rule-engine/Dockerfile
+++ b/services/rule-engine/Dockerfile
@@ -1,5 +1,5 @@
 # services/rule-engine/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \

--- a/services/wallet/Dockerfile
+++ b/services/wallet/Dockerfile
@@ -1,5 +1,5 @@
 # services/wallet/Dockerfile
-FROM python:3.14.0rc3-slim-trixie
+FROM python:3.12-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \


### PR DESCRIPTION
## Summary
- switch all service Dockerfiles to use the stable python:3.12-slim image so that pydantic-core installs prebuilt wheels

## Testing
- docker build services/forex  (fails: docker not installed in CI environment)
- docker build services/ledger  (fails: docker not installed in CI environment)
- docker build services/payment  (fails: docker not installed in CI environment)
- docker build services/profile  (fails: docker not installed in CI environment)
- docker build services/rule-engine  (fails: docker not installed in CI environment)
- docker build services/wallet  (fails: docker not installed in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddc2d2574c832488545373ef53f065