### PR TITLE
Rename Keycloak healthcheck Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,8 @@ services:
     restart: unless-stopped
 
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    build:
+      context: ./keycloak
     command: ["start-dev", "--import-realm"]
     environment:
       KEYCLOAK_ADMIN: admin

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM quay.io/keycloak/keycloak:latest AS builder
+
+FROM eclipse-temurin:21-jre-jammy
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/keycloak /opt/keycloak
+
+RUN groupadd -r keycloak \
+    && useradd -r -g keycloak -d /opt/keycloak -s /bin/sh keycloak \
+    && chown -R keycloak:keycloak /opt/keycloak
+
+USER keycloak
+
+WORKDIR /opt/keycloak
+
+ENV KC_HEALTH_ENABLED=true
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+
+CMD ["start"]


### PR DESCRIPTION
## Summary
- rename the derived Keycloak image definition to the standard Dockerfile name
- adjust docker-compose to build the Keycloak service from the renamed Dockerfile

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddc9ca6cbc8324a521eac7b02034b3