### PR TITLE
Build otel collector image with curl for health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,9 @@ services:
     restart: unless-stopped
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    build:
+      context: .
+      dockerfile: otel/Dockerfile
     command: ["--config=/etc/otelcol/config.yaml"]
     volumes:
       - ./otel/collector.yaml:/etc/otelcol/config.yaml:ro

--- a/otel/Dockerfile
+++ b/otel/Dockerfile
@@ -1,0 +1,8 @@
+# Multi-stage image to provide lightweight collector with curl for health checks
+FROM otel/opentelemetry-collector-contrib:latest AS collector
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates curl
+COPY --from=collector /otelcol-contrib /otelcol-contrib
+ENTRYPOINT ["/otelcol-contrib"]
+CMD ["--config=/etc/otelcol/config.yaml"]


### PR DESCRIPTION
## Summary
- add a lightweight Dockerfile that copies the collector binary into an Alpine base with curl
- update the otel-collector service to build from the new Dockerfile so HTTP health checks can run
- rename the collector Dockerfile to use the conventional name and point compose at it

## Testing
- Not run (docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ddc9da0b3483248e01981ba72d6772