### PR TITLE
Update Jaeger healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "16686:16686"
       - "4317:4317"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:14269/health"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:14269/"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the Jaeger healthcheck probe to use the root admin endpoint that returns HTTP 200

## Testing
- docker compose up jaeger *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddced08954832496fbaf775ac54a86