### PR TITLE
Remove Jaeger curl healthcheck and adjust collector dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,6 @@ services:
     ports:
       - "16686:16686"
       - "4317:4317"
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:14269/"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
     deploy:
       resources:
         limits:
@@ -68,7 +62,7 @@ services:
       - ./otel/collector.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
       jaeger:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:13133/healthz"]
       interval: 10s


### PR DESCRIPTION
## Summary
- remove the Jaeger healthcheck that invoked curl
- relax the OpenTelemetry collector dependency to wait for the Jaeger service to start

## Testing
- docker compose down *(fails: docker not available in environment)*
- docker compose --compatibility up -d --build *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd3cc71d08324ae8995e70d48cb11