### PR TITLE
Configure per-service Celery queues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,7 +303,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "profile-worker@%h"
+        "profile-worker@%h",
+        "--queues",
+        "profile-tasks"
       ]
     environment:
       <<: *svc_env
@@ -357,7 +359,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "payment-worker@%h"
+        "payment-worker@%h",
+        "--queues",
+        "payment-tasks"
       ]
     environment:
       <<: *svc_env
@@ -411,7 +415,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "ledger-worker@%h"
+        "ledger-worker@%h",
+        "--queues",
+        "ledger-tasks"
       ]
     environment:
       <<: *svc_env
@@ -465,7 +471,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "wallet-worker@%h"
+        "wallet-worker@%h",
+        "--queues",
+        "wallet-tasks"
       ]
     environment:
       <<: *svc_env
@@ -519,7 +527,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "rule-engine-worker@%h"
+        "rule-engine-worker@%h",
+        "--queues",
+        "rule-engine-tasks"
       ]
     environment:
       <<: *svc_env
@@ -573,7 +583,9 @@ services:
         "--concurrency",
         "2",
         "--hostname",
-        "forex-worker@%h"
+        "forex-worker@%h",
+        "--queues",
+        "forex-tasks"
       ]
     environment:
       <<: *svc_env

--- a/services/forex/app/celery_app.py
+++ b/services/forex/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "forex-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )

--- a/services/ledger/app/celery_app.py
+++ b/services/ledger/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "ledger-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )

--- a/services/payment/app/celery_app.py
+++ b/services/payment/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "payment-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )

--- a/services/profile/app/celery_app.py
+++ b/services/profile/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "profile-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )

--- a/services/rule-engine/app/celery_app.py
+++ b/services/rule-engine/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "rule-engine-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )

--- a/services/wallet/app/celery_app.py
+++ b/services/wallet/app/celery_app.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from kombu import Queue
 
 redis_password = os.getenv("REDIS_PASSWORD", "")
 default_broker = (
@@ -14,9 +15,13 @@ celery_app = Celery(
     include=["tasks"],
 )
 
+queue_name = os.getenv("CELERY_DEFAULT_QUEUE", "wallet-tasks")
+
 celery_app.conf.update(
     task_acks_late=True,
     worker_prefetch_multiplier=1,
     enable_utc=True,
     timezone="UTC",
+    task_default_queue=queue_name,
+    task_queues=(Queue(queue_name),),
 )


### PR DESCRIPTION
## Summary
- set each service Celery application to use a service-specific default queue and queue declaration
- scope every worker in docker-compose.yml to its domain queue so producers and consumers stay aligned

## Testing
- docker compose build profile profile-worker payment payment-worker ledger ledger-worker wallet wallet-worker rule-engine rule-engine-worker forex forex-worker *(fails: `docker` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd6a605f08324afc7a5e1e225cd29