### PR TITLE
Update Keycloak Dockerfile to use official base image

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,22 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM quay.io/keycloak/keycloak:latest AS builder
+FROM quay.io/keycloak/keycloak:26.4
 
-FROM eclipse-temurin:21-jre-jammy
+USER root
+RUN microdnf install -y curl \
+    && microdnf clean all
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /opt/keycloak /opt/keycloak
-
-RUN groupadd -r keycloak \
-    && useradd -r -g keycloak -d /opt/keycloak -s /bin/sh keycloak \
-    && chown -R keycloak:keycloak /opt/keycloak
-
-USER keycloak
-
-WORKDIR /opt/keycloak
+USER 1000
 
 ENV KC_HEALTH_ENABLED=true
 


### PR DESCRIPTION
## Summary
- replace the custom multi-stage build with quay.io/keycloak/keycloak:26.4
- install curl via microdnf and clean the package cache
- rely on the image default user while keeping KC_HEALTH_ENABLED enabled

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68ddd9238a048324a23e10f5ce42f55c