### PR TITLE
Update Keycloak bootstrap admin env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,8 @@ services:
       context: ./keycloak
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     ports:


### PR DESCRIPTION
## Summary
- replace deprecated Keycloak admin environment variable names with their bootstrap equivalents in docker-compose

## Testing
- ❌ `docker compose down` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dddead2bc48324a4d9cf82ca1e51e8