### PR TITLE
Update Keycloak health check to use management port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health/ready"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/health/ready"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- point the Keycloak healthcheck curl command at the management health endpoint exposed when KC_HEALTH_ENABLED is true

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dddeb2827c832498c8dc8d156e105f