### PR TITLE
Refactor Keycloak Dockerfile to vendor curl from UBI builder

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,15 +1,16 @@
 # syntax=docker/dockerfile:1
+FROM registry.access.redhat.com/ubi9 AS curl-builder
+
+RUN dnf install -y --setopt=install_weak_deps=False curl \
+    && dnf clean all \
+    && mkdir -p /curl-root/usr/bin \
+    && cp /usr/bin/curl /curl-root/usr/bin/ \
+    && ldd /usr/bin/curl | awk '{print $3}' | grep '^/' | xargs -I '{}' cp --parents '{}' /curl-root
 
 FROM quay.io/keycloak/keycloak:26.4
-
 USER root
-RUN microdnf install -y curl \
-    && microdnf clean all
-
+COPY --from=curl-builder /curl-root/ /
 USER 1000
-
 ENV KC_HEALTH_ENABLED=true
-
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
-
 CMD ["start"]


### PR DESCRIPTION
## Summary
- add a UBI-based builder stage that installs curl with dnf
- copy the curl binary and its shared libraries into the final Keycloak image while preserving the existing runtime configuration

## Testing
- docker build -t custom-keycloak:latest keycloak *(fails: `docker` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde19c60a883248e2815cdb23f0ae1