### PR TITLE
Add default Keycloak users for realm roles

### DIFF
--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -128,5 +128,82 @@
             ]
         }
     ],
-    "browserFlow": "innover-browser"
+    "browserFlow": "innover-browser",
+    "users": [
+        {
+            "username": "admin",
+            "enabled": true,
+            "emailVerified": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "admin",
+                    "temporary": false
+                }
+            ],
+            "realmRoles": [
+                "admin"
+            ]
+        },
+        {
+            "username": "ops_user",
+            "enabled": true,
+            "emailVerified": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "ops_user",
+                    "temporary": false
+                }
+            ],
+            "realmRoles": [
+                "ops_user"
+            ]
+        },
+        {
+            "username": "finance",
+            "enabled": true,
+            "emailVerified": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "finance",
+                    "temporary": false
+                }
+            ],
+            "realmRoles": [
+                "finance"
+            ]
+        },
+        {
+            "username": "auditor",
+            "enabled": true,
+            "emailVerified": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "auditor",
+                    "temporary": false
+                }
+            ],
+            "realmRoles": [
+                "auditor"
+            ]
+        },
+        {
+            "username": "user",
+            "enabled": true,
+            "emailVerified": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "user",
+                    "temporary": false
+                }
+            ],
+            "realmRoles": [
+                "user"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- add default admin user and role-specific accounts to the Keycloak realm export
- configure permanent password credentials so each seeded user is ready for login

## Testing
- `jq . keycloak/realm-export.json`


------
https://chatgpt.com/codex/tasks/task_e_68ddfce5b5e08324873496f795cd0157