### PR TITLE
Add realm roles mapper to Kong client Keycloak export

### DIFF
--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -64,6 +64,20 @@
                         "claim.name": "preferred_username",
                         "jsonType.label": "String"
                     }
+                },
+                {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "claim.name": "roles",
+                        "jsonType.label": "String",
+                        "multivalued": "true",
+                        "access.token.claim": "true",
+                        "id.token.claim": "true",
+                        "userinfo.token.claim": "true"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
## Summary
- add a Keycloak realm role protocol mapper for the Kong client so roles are included in tokens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddff03bccc8324b61250d4c351a7c6