### PR TITLE
Fix Keycloak introspection auth method for Kong

### DIFF
--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -16,7 +16,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile
@@ -44,7 +44,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile
@@ -66,7 +66,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile
@@ -88,7 +88,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile
@@ -110,7 +110,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile
@@ -132,7 +132,7 @@ services:
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
               introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
-              introspection_endpoint_auth_method: client_secret_post
+              introspection_endpoint_auth_method: client_secret_basic
               scopes:
                 - openid
                 - profile


### PR DESCRIPTION
## Summary
- configure the Kong OIDC plugin to authenticate against Keycloak's introspection endpoint using client_secret_basic instead of client_secret_post
- ensure bearer token validation succeeds for protected services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de40e7961c8324b9e3d56c8d198f55