### PR TITLE
Point Kong OIDC plugins to internal Keycloak host

### DIFF
--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -10,11 +10,11 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
+              issuer: http://keycloak:8080/realms/innover
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               bearer_only: yes
               ssl_verify: no
               realm: innover
@@ -42,12 +42,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -64,12 +64,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -86,12 +86,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -108,12 +108,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -130,12 +130,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid


### PR DESCRIPTION
## Summary
- update each openid-connect plugin in the Kong declarative config to reference the keycloak service host that Kong can reach
- keep issuer, discovery, and introspection endpoints aligned with the new Keycloak base URL to avoid mismatches

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68df1107ace0832494e39655a8e4ea66