### PR TITLE
Remove nginx proxy from compose and update Keycloak references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 x-svc-env: &svc_env
-  OIDC_ISSUER: ${OIDC_ISSUER:-http://nginx/auth/realms/innover}
+  OIDC_ISSUER: ${OIDC_ISSUER:-http://keycloak:8080/realms/innover}
   OIDC_AUDIENCE: ${OIDC_AUDIENCE:-kong}
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
   REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret}
@@ -91,20 +91,6 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  nginx:
-    image: nginx:alpine
-    container_name: nginx-proxy
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-    ports:
-      - "80:80"
-    depends_on:
-      keycloak:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - default
-
   keycloak:
     build:
       context: ./keycloak
@@ -165,12 +151,9 @@ services:
       - "8001:8001"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-      - "keycloak-external:host-gateway"
     depends_on:
       keycloak:
         condition: service_healthy
-      nginx:
-        condition: service_started
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s

--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -10,11 +10,11 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
+              issuer: http://keycloak:8080/realms/innover
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               bearer_only: yes
               ssl_verify: no
               realm: innover
@@ -42,12 +42,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -64,12 +64,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -86,12 +86,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -108,12 +108,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid
@@ -130,12 +130,12 @@ services:
         plugins:
           - name: openid-connect
             config:
-              issuer: http://nginx/auth/realms/innover
-              discovery: http://nginx/auth/realms/innover/.well-known/openid-configuration
+              issuer: http://keycloak:8080/realms/innover
+              discovery: http://keycloak:8080/realms/innover/.well-known/openid-configuration
               client_id: kong
               client_secret: ${KONG_OIDC_CLIENT_SECRET}
               bearer_only: true
-              introspection_endpoint: http://nginx/auth/realms/innover/protocol/openid-connect/token/introspect
+              introspection_endpoint: http://keycloak:8080/realms/innover/protocol/openid-connect/token/introspect
               introspection_endpoint_auth_method: client_secret_post
               scopes:
                 - openid

--- a/services/common/auth.py
+++ b/services/common/auth.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 security = HTTPBearer()
 
 # Environment variables with fallbacks
-KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://nginx/auth")
+KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://keycloak:8080")
 KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "innover")
 OIDC_ISSUER = os.getenv("OIDC_ISSUER", f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}")
 


### PR DESCRIPTION
## Summary
- remove the nginx proxy service from the compose stack and update OIDC defaults to target Keycloak directly
- update Kong's declarative configuration and shared auth defaults to use the Keycloak service endpoints

## Testing
- docker compose down *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df112f0f58832493d49b42a3ffe59f