### PR TITLE
Automate WSO2 Keycloak configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := /bin/bash
 # Start all services
 up:
 	docker compose up -d --build
+	$(MAKE) configure-keycloak
 
 # Rebuild without cache
 rebuild:


### PR DESCRIPTION
## Summary
- extend `make up` to run the Keycloak configurator so WSO2 gets wired automatically
- refactor `wso2/configure-keycloak.py` to poll for service readiness, honor env variables, and reuse the Admin API for create/update flows
- document the new automation in the Keycloak + WSO2 checklist and note the standalone `make configure-keycloak` helper

## Testing
- python -m compileall wso2/configure-keycloak.py

------
https://chatgpt.com/codex/tasks/task_e_68df5056604c83249d0b8a25af2bba40