### PR TITLE
Fix Keycloak issuer alignment for WSO2 host access

### DIFF
--- a/.env
+++ b/.env
@@ -8,9 +8,12 @@ REDIS_PASSWORD=redis-secret
 # ====== WSO2 API Manager OIDC Configuration ======
 WSO2_AM_CLIENT_ID=wso2am
 WSO2_AM_CLIENT_SECRET=wso2am-secret
-# Issuer must match the URL used to generate tokens (from host = localhost)
+# Public issuer must match the URL that end-users hit when requesting tokens
+KEYCLOAK_PUBLIC_BASE_URL=http://localhost:8080
+KEYCLOAK_PUBLIC_REALM_URL=http://localhost:8080/realms/innover
 KEYCLOAK_ISSUER=http://localhost:8080/realms/innover
 # Internal URL for WSO2 setup container to fetch .well-known config
+KEYCLOAK_INTERNAL_BASE_URL=http://keycloak:8080
 KEYCLOAK_INTERNAL_REALM_URL=http://keycloak:8080/realms/innover
 # ====== Keycloak Admin ======
 KC_BOOTSTRAP_ADMIN_USERNAME=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,11 @@ services:
       KC_DB_URL: jdbc:postgresql://keycloak-database:5432/keycloak
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-keycloakpass}
+      KC_HOSTNAME_URL: ${KEYCLOAK_PUBLIC_BASE_URL:-http://localhost:8080}
+      KC_HOSTNAME_ADMIN_URL: ${KEYCLOAK_INTERNAL_BASE_URL:-http://keycloak:8080}
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_PROXY_HEADERS: xforwarded
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     healthcheck:
@@ -149,6 +154,8 @@ services:
       WSO2_ADMIN_USERNAME: admin
       WSO2_ADMIN_PASSWORD: admin
       KEYCLOAK_INTERNAL_REALM_URL: http://keycloak:8080/realms/innover
+      KEYCLOAK_PUBLIC_BASE_URL: http://localhost:8080
+      KEYCLOAK_PUBLIC_REALM_URL: http://localhost:8080/realms/innover
       KEYCLOAK_ISSUER: http://localhost:8080/realms/innover
       WSO2_AM_CLIENT_ID: ${WSO2_AM_CLIENT_ID:-wso2am}
       WSO2_AM_CLIENT_SECRET: ${WSO2_AM_CLIENT_SECRET:-wso2am-secret}


### PR DESCRIPTION
## Summary
- configure the Keycloak container with explicit public and internal hostnames so issued tokens align with the host-facing issuer
- update the WSO2 automation to use the new public issuer while keeping internal endpoints for back-channel calls
- document the new Keycloak URL settings in the environment template for easier overrides

## Testing
- python -m compileall wso2/configure-keycloak.py

------
https://chatgpt.com/codex/tasks/task_e_68dfef30235c8324b357822ab1caf90a