### PR TITLE
Fix Keycloak key manager configuration for JWT validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ This repository is a fully containerized playground for an event-driven payments
 - **JWKS integration**: WSO2 fetches public keys from Keycloak automatically
 - **No token duplication**: Use Keycloak tokens directly with WSO2 APIs
 
+#### End-to-end authentication and routing story
+
+1. **User login** – A user signs into Keycloak (via the hosted login UI or an application using the OpenID Connect flow) and receives an access token that contains the user's realm and client roles.
+2. **Token presentation** – The client calls a published API on the WSO2 gateway and presents the Keycloak access token in the `Authorization: Bearer` header.
+3. **Token validation** – WSO2 verifies the JWT signature and issuer against Keycloak's JWKS endpoint, so no additional token minting is required inside WSO2.
+4. **Authorization decision** – WSO2 reads the embedded roles to enforce subscription policies and resource-level permissions that have been configured for the API.
+5. **API routing** – Once the token is validated and authorized, WSO2 forwards the request to the configured backend microservice endpoint. The backend trusts the already-validated token context or performs additional in-service checks as needed.
+
+This flow keeps Keycloak as the single source of truth for identity while allowing WSO2 to handle policy enforcement, observability, and backend routing for every API invocation.
+
 **Run the Key Manager setup**:
 
 **Test with Keycloak token**:

--- a/wso2/configure-keycloak-km.py
+++ b/wso2/configure-keycloak-km.py
@@ -144,12 +144,12 @@ class KeyManagerConfigurator:
             "type": "default",  # Use default type, not Keycloak-specific
             "description": "Keycloak Key Manager for JWT validation",
             "enabled": True,
-            
+
             # For JWT validation at the Gateway:
             "issuer": keycloak_issuer,
             "scopesClaim": "scope",
             "consumerKeyClaim": "azp",
-            
+
             # Endpoints as individual top-level fields
             "introspectionEndpoint": introspect_ep,
             "tokenEndpoint": token_ep,
@@ -157,26 +157,39 @@ class KeyManagerConfigurator:
             "authorizeEndpoint": authorize_ep,
             "clientRegistrationEndpoint": reg_ep,
             "userInfoEndpoint": userinfo_ep,
-            
+            "wellKnownEndpoint": well_known,
+
             # Certificates for JWT validation
             "certificates": {
                 "type": "JWKS",
                 "value": jwks_ep
             },
-            
-            # Tell APIM we validate JWTs
+
+            # Tell APIM we validate JWTs using the JWKS endpoint from Keycloak
             "tokenValidation": [
                 {
-                    "type": "jwt",
-                    "value": {}
+                    "type": "JWT",
+                    "value": {
+                        "jwksEndpoint": jwks_ep,
+                        "issuer": keycloak_issuer
+                    }
                 }
             ],
-            
-            # Additional properties as key-value object
-            "additionalProperties": {
-                "client_id": km_client_id,
-                "client_secret": km_client_secret,
-            },
+
+            # Additional properties must be provided as a list of name/value objects
+            "additionalProperties": [
+                {"name": "client_id", "value": km_client_id},
+                {"name": "client_secret", "value": km_client_secret},
+                {"name": "scopeClaim", "value": "scope"},
+            ],
+
+            # Grant types that the external KM supports (matches Keycloak defaults)
+            "availableGrantTypes": [
+                "authorization_code",
+                "client_credentials",
+                "password",
+                "refresh_token",
+            ],
         }
         
         # Create or update


### PR DESCRIPTION
## Summary
- configure the Keycloak key manager payload with a JWKS-backed JWT validation block
- provide well-known metadata, supported grant types, and proper additional property formatting for WSO2

## Testing
- python -m py_compile wso2/configure-keycloak-km.py

------
https://chatgpt.com/codex/tasks/task_e_68e120ac56888324b79578e8217e3620