### PR TITLE
Fix service build contexts for shared modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -485,7 +485,9 @@ services:
     networks: [edge]
 
   wallet-worker:
-    build: ./services/wallet
+    build:
+      context: ./services
+      dockerfile: wallet/Dockerfile
     working_dir: /app
     command:
       [
@@ -523,7 +525,9 @@ services:
     networks: [edge]
 
   rule-engine:
-    build: ./services/rule-engine
+    build:
+      context: ./services
+      dockerfile: rule-engine/Dockerfile
     environment:
       <<: *svc_env
       SERVICE_NAME: svc-rules
@@ -553,7 +557,9 @@ services:
     networks: [edge]
 
   rule-engine-worker:
-    build: ./services/rule-engine
+    build:
+      context: ./services
+      dockerfile: rule-engine/Dockerfile
     working_dir: /app
     command:
       [
@@ -597,7 +603,9 @@ services:
     networks: [edge]
 
   forex:
-    build: ./services/forex
+    build:
+      context: ./services
+      dockerfile: forex/Dockerfile
     environment:
       <<: *svc_env
       SERVICE_NAME: svc-forex


### PR DESCRIPTION
## Summary
- update docker-compose build contexts for the wallet worker, rule engine, and forex services to use the shared services directory
- ensure the Dockerfiles can copy the common module and requirements without build errors

## Testing
- docker compose build wallet-worker rule-engine forex *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e413a962848324be3098f9279ff895