### PR TITLE
Add python-jose dependency to service requirements

### DIFF
--- a/services/forex/app/requirements.txt
+++ b/services/forex/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1

--- a/services/ledger/app/requirements.txt
+++ b/services/ledger/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1

--- a/services/payment/app/requirements.txt
+++ b/services/payment/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1

--- a/services/profile/app/requirements.txt
+++ b/services/profile/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1

--- a/services/rule-engine/app/requirements.txt
+++ b/services/rule-engine/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1

--- a/services/wallet/app/requirements.txt
+++ b/services/wallet/app/requirements.txt
@@ -1,3 +1,4 @@
 celery[redis]==5.4.0
 fastapi==0.111.0
+python-jose[cryptography]==3.3.0
 uvicorn[standard]==0.30.1


### PR DESCRIPTION
## Summary
- add python-jose with cryptography extras to each service requirements list to satisfy token decoding dependency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e41f7a56908324bccf20e737a55b5e