### PR TITLE
Enable automatic WSO2 IS key manager provisioning

### DIFF
--- a/wso2/CHANGES.md
+++ b/wso2/CHANGES.md
@@ -1,5 +1,12 @@
 # WSO2 Initialization Fix - Changes Summary
 
+## 2025-02-14 - Automated WSO2 IS Key Manager Enablement
+
+- Set the external WSO2 IS key manager to enabled by default in `deployment.toml` with complete OpenID Connect metadata.
+- Added an idempotent Admin REST helper (`enable_wso2is_keymanager.py`) that creates the key manager configuration if it is missing and updates it when disabled.
+- Wired the setup container to call the helper automatically before provisioning APIs so the admin experience requires no manual toggles.
+- Documented the grant types, issuer, and JWKS endpoints to align with the multi-role user bootstrap supplied by `wso2is/create-users.sh`.
+
 ## Problem
 
 WSO2 API Manager initialization was failing with:

--- a/wso2/deployment.toml
+++ b/wso2/deployment.toml
@@ -28,7 +28,8 @@ name = "WSO2IS"
 type = "WSO2-IS"
 display_name = "WSO2 Identity Server"
 description = "Financial-grade Identity Server for PCI-DSS compliance"
-enabled = false  # Disabled during initial setup, enable after both services are stable
+enabled = true
+is_default = true
 
 [apim.key_manager.configuration]
 ServerURL = "https://wso2is:9443/services/"
@@ -41,6 +42,13 @@ UserInfoURL = "https://wso2is:9443/oauth2/userinfo"
 AuthorizeURL = "https://wso2is:9443/oauth2/authorize"
 TokenValidation = "INTROSPECT"
 ClaimConfiguration = "use_user_store_as_claim_dialect"
+WellKnownEndpoint = "https://wso2is:9443/oauth2/.well-known/openid-configuration"
+Issuer = "https://wso2is:9443/oauth2/token"
+JWKSEndpoint = "https://wso2is:9443/oauth2/jwks"
+ConsumerKeyClaim = "azp"
+ScopesClaim = "scope"
+Audience = "wso2am"
+KeyManagerClientConfiguration = "{\"GrantTypes\": [\"password\", \"client_credentials\", \"refresh_token\", \"urn:ietf:params:oauth:grant-type:jwt-bearer\"]}"
 
 # JWT Token Validation - WSO2 IS Integration
 [apim.jwt]

--- a/wso2/enable_wso2is_keymanager.py
+++ b/wso2/enable_wso2is_keymanager.py
@@ -8,13 +8,75 @@ import sys
 import requests
 import base64
 import json
-from typing import Dict
+from typing import Dict, Any
 
 # Disable SSL warnings for dev environment
 requests.packages.urllib3.disable_warnings()
 
 
-def enable_key_manager(wso2_host: str, username: str, password: str) -> bool:
+def build_key_manager_payload(wso2_is_host: str, username: str, password: str) -> Dict[str, Any]:
+    """Construct payload used for the Admin REST API."""
+
+    wso2_is_host = wso2_is_host.rstrip("/")
+
+    configuration: Dict[str, Any] = {
+        "ServerURL": f"{wso2_is_host}/services/",
+        "Username": username,
+        "Password": password,
+        "TokenURL": f"{wso2_is_host}/oauth2/token",
+        "RevokeURL": f"{wso2_is_host}/oauth2/revoke",
+        "IntrospectURL": f"{wso2_is_host}/oauth2/introspect",
+        "UserInfoURL": f"{wso2_is_host}/oauth2/userinfo",
+        "AuthorizeURL": f"{wso2_is_host}/oauth2/authorize",
+        "JWKSEndpoint": f"{wso2_is_host}/oauth2/jwks",
+        "WellKnownEndpoint": f"{wso2_is_host}/oauth2/.well-known/openid-configuration",
+        "Issuer": f"{wso2_is_host}/oauth2/token",
+        "TokenValidation": "INTROSPECT",
+        "ClaimConfiguration": "use_user_store_as_claim_dialect",
+        "ConsumerKeyClaim": "azp",
+        "ScopesClaim": "scope",
+        "Audience": "wso2am",
+        "KeyManagerClientConfiguration": {
+            "GrantTypes": [
+                "password",
+                "client_credentials",
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ]
+        },
+    }
+
+    return {
+        "name": "WSO2IS",
+        "displayName": "WSO2 Identity Server",
+        "type": "WSO2-IS",
+        "description": "WSO2 Identity Server as external Key Manager",
+        "enabled": True,
+        "isDefault": True,
+        "tokenType": "JWT",
+        "alias": "WSO2IS",
+        "configuration": configuration,
+        "additionalProperties": {},
+        "claimMapping": [
+            {
+                "remoteClaim": "sub",
+                "localClaim": "http://wso2.org/claims/username",
+            },
+            {
+                "remoteClaim": "email",
+                "localClaim": "http://wso2.org/claims/emailaddress",
+            },
+        ],
+        "scopeMappings": [],
+        "certificate": {
+            "type": "JWKS",
+            "value": "",
+            "alias": "",
+        },
+    }
+
+
+def enable_key_manager(wso2_host: str, username: str, password: str, wso2_is_host: str | None = None) -> bool:
     """Enable WSO2 IS Key Manager via REST API"""
     print("=" * 60)
     print("WSO2 IS Key Manager Enablement")
@@ -26,6 +88,7 @@ def enable_key_manager(wso2_host: str, username: str, password: str) -> bool:
     admin_api = f"{wso2_host}/api/am/admin/v4"
     token_endpoint = f"{wso2_host}/oauth2/token"
     dcr_endpoint = f"{wso2_host}/client-registration/v0.17/register"
+    wso2_is_host = (wso2_is_host or os.getenv("WSO2_IS_HOST", "https://wso2is:9443")).rstrip("/")
     
     # Step 1: Get access token
     print("\n🔑 Obtaining access token...")
@@ -112,36 +175,49 @@ def enable_key_manager(wso2_host: str, username: str, password: str) -> bool:
             wso2is_km = km
             break
     
+    payload = build_key_manager_payload(wso2_is_host, username, password)
+
     if not wso2is_km:
-        print("\n❌ WSO2 IS Key Manager not found in configuration")
-        print("   Please add it to deployment.toml first")
-        return False
-    
+        print("\nℹ️  WSO2 IS Key Manager not found. Creating new configuration via Admin REST API...")
+
+        create_response = session.post(
+            f"{admin_api}/key-managers",
+            json=payload,
+            headers={"Content-Type": "application/json"}
+        )
+
+        if create_response.status_code not in (200, 201):
+            print(f"❌ Failed to create Key Manager: {create_response.status_code}")
+            print(f"   Response: {create_response.text[:300]}")
+            return False
+
+        print("✓ WSO2 IS Key Manager created and enabled")
+        return True
+
     km_id = wso2is_km["id"]
-    
-    # Step 4: Enable the Key Manager
+
     if wso2is_km.get("enabled", False):
         print(f"\n✓ WSO2 IS Key Manager is already enabled")
         return True
-    
-    print(f"\n🔧 Enabling WSO2 IS Key Manager (ID: {km_id})...")
-    
-    # Update the Key Manager configuration
-    wso2is_km["enabled"] = True
-    
+
+    print(f"\n🔧 Updating WSO2 IS Key Manager configuration (ID: {km_id})...")
+
+    updated_payload: Dict[str, Any] = {**wso2is_km, **payload}
+    updated_payload["id"] = km_id
+
     update_response = session.put(
         f"{admin_api}/key-managers/{km_id}",
-        json=wso2is_km,
+        json=updated_payload,
         headers={"Content-Type": "application/json"}
     )
-    
-    if update_response.status_code == 200:
-        print("✓ WSO2 IS Key Manager enabled successfully")
-        return True
-    else:
+
+    if update_response.status_code not in (200, 202):
         print(f"❌ Failed to enable Key Manager: {update_response.status_code}")
         print(f"   Response: {update_response.text[:300]}")
         return False
+
+    print("✓ WSO2 IS Key Manager enabled successfully")
+    return True
 
 
 def main():
@@ -149,8 +225,9 @@ def main():
     wso2_host = os.getenv("WSO2_HOST", "https://localhost:9443")
     wso2_username = os.getenv("WSO2_ADMIN_USERNAME", "admin")
     wso2_password = os.getenv("WSO2_ADMIN_PASSWORD", "admin")
-    
-    success = enable_key_manager(wso2_host, wso2_username, wso2_password)
+    wso2_is_host = os.getenv("WSO2_IS_HOST", "https://localhost:9444")
+
+    success = enable_key_manager(wso2_host, wso2_username, wso2_password, wso2_is_host)
     
     if success:
         print("\n" + "=" * 60)
@@ -158,8 +235,7 @@ def main():
         print("=" * 60)
         print("\nNext steps:")
         print("1. Restart WSO2 API Manager for changes to take effect")
-        print("2. Update deployment.toml to set 'enabled = true'")
-        print("3. Re-run the setup script if needed")
+        print("2. Re-run the setup script if additional APIs need provisioning")
         sys.exit(0)
     else:
         print("\n" + "=" * 60)

--- a/wso2/setup.py
+++ b/wso2/setup.py
@@ -12,6 +12,7 @@ import base64
 import requests
 from typing import Dict, List, Optional
 from urllib.parse import urljoin
+from enable_wso2is_keymanager import enable_key_manager as enable_wso2is_key_manager
 
 # Disable SSL warnings for dev environment
 requests.packages.urllib3.disable_warnings()
@@ -770,7 +771,7 @@ def main():
     
     # Environment variables
     wso2_host = os.getenv("WSO2_HOST", "https://wso2am:9443")
-    wso2is_host = os.getenv("WSO2_IS_HOST", "https://wso2is:9444")
+    wso2is_host = os.getenv("WSO2_IS_HOST", "https://wso2is:9443")
     wso2_username = os.getenv("WSO2_ADMIN_USERNAME", "admin")
     wso2_password = os.getenv("WSO2_ADMIN_PASSWORD", "admin")
     config_file = os.getenv("API_CONFIG_FILE", "/config/api-config.yaml")
@@ -783,7 +784,17 @@ def main():
     
     # Wait for WSO2 to be ready
     client.wait_for_ready()
-    
+
+    # Optionally ensure the external key manager is enabled before provisioning APIs
+    if os.getenv("ENABLE_WSO2IS_KEY_MANAGER", "true").lower() in {"1", "true", "yes"}:
+        print("\n" + "=" * 60)
+        print("Ensuring WSO2 IS Key Manager is enabled")
+        print("=" * 60)
+
+        if not enable_wso2is_key_manager(wso2_host, wso2_username, wso2_password, wso2is_host):
+            print("\n❌ Unable to enable WSO2 IS as Key Manager. Aborting setup.")
+            sys.exit(1)
+
     # Get access token
     client.get_access_token()
     


### PR DESCRIPTION
## Summary
- enable the WSO2 Identity Server key manager by default with complete OIDC metadata in deployment.toml
- make the key-manager helper create or update the configuration via the Admin REST API and invoke it from the setup workflow
- document the automated key manager enablement in the WSO2 change log

## Testing
- python -m py_compile wso2/*.py

------
https://chatgpt.com/codex/tasks/task_e_68e430f358508324a31b3bd29396d0ba